### PR TITLE
Add neovim highlight queries

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,27 @@
+[
+ "datasource"
+ "enum"
+ "generator"
+ "model"
+] @keyword
+
+(comment) @comment
+(developer_comment) @comment
+
+(arguments) @property
+(attribute) @function
+(call_expression) @function
+(column_type) @type
+(enumeral) @constant
+(identifier) @variable
+(string) @string
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"=" @operator
+"@" @operator
+


### PR DESCRIPTION
Hello there, thank you for putting together this repo. I went ahead and updated the `tree-sitter-cli` dependency to be able to use this in neovim (it required ABI >= 13), I also added the required queries for the highlighting to work. Here's how it ended up looking:

![image](https://user-images.githubusercontent.com/8370058/141382378-7d14fce3-f069-45ee-9313-0eb9c05c5e51.png)

If you're ok with merging this, I plan to send a PR to [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) to have this listed in the 'Supported languages' section and I can keep an eye on potential updates that need to be made given that it [looks like](https://github.com/victorhqc/tree-sitter-prisma/issues/27#issuecomment-926922280) neovim is not your preferred text editor :) 